### PR TITLE
Feature/deprecate arguments section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxygen"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["geo-ant"]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "Seamlessly document function parameters with rustdoc"
 readme = "Readme.md"
 categories = ["rust-patterns","development-tools"]
 keywords = ["document", "function", "parameters", "arguments", "doxygen"]
+maintenance = { status = "passively-maintained" }
 
 [lib]
 proc-macro = true

--- a/Readme.md
+++ b/Readme.md
@@ -54,9 +54,9 @@ fn sum_image_rows(
 }
 ```
 
-## Placing the Arguments-Section
+## Placing the Parameters-Section
 
-By default, the section documenting the arguments will go at the end
+By default, the section documenting the parameters will go at the end
 of the top-level function documentation. However, this crate allows to explicitly
 place the section by using a custom attribute like so:
 

--- a/Readme.md
+++ b/Readme.md
@@ -62,12 +62,12 @@ of the top-level function documentation. However, this crate allows to explicitl
 place the section by using a custom attribute like so:
 
 ```rust
-use roxygen::*;
+use roxygen::roxygen;
 
 #[roxygen]
 /// long documention
 /// ...
-#[arguments_section]
+#[roxygen::parameters_section]
 /// # Examples
 /// ...
 fn foo(

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,6 @@
 ![tests](https://github.com/geo-ant/roxygen/actions/workflows/tests.yml/badge.svg?branch=main)
 ![lints](https://github.com/geo-ant/roxygen/actions/workflows/lints.yml/badge.svg?branch=main)
 [![crates](https://img.shields.io/crates/v/roxygen)](https://crates.io/crates/roxygen)
-![maintenance-status](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 
 The `#[roxygen]` attribute allows you to add doc-comments to function
 parameters, which is a _compile error_ in current Rust. Generic lifetimes,

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Attribute, Expr, FnArg, Generics, Ident, LitStr, Meta, MetaNameValue, Pat};
 
-use crate::is_arguments_section;
+use crate::is_parameters_section;
 
 /// Function to prepend a string to a `#[doc]` attribute.
 pub fn prepend_to_doc_attribute(prepend_text: &str, attr: &Attribute) -> proc_macro2::TokenStream {
@@ -72,7 +72,7 @@ pub fn extract_fn_doc_attrs(attrs: &mut Vec<Attribute>) -> Result<FunctionDocs, 
     // parse the arguments before the arguments-section attribute
     while idx < attrs.len() {
         let current_attr = attrs.get(idx).unwrap();
-        if is_arguments_section(current_attr) {
+        if is_parameters_section(current_attr) {
             idx += 1;
             break;
         }
@@ -84,7 +84,7 @@ pub fn extract_fn_doc_attrs(attrs: &mut Vec<Attribute>) -> Result<FunctionDocs, 
 
     while idx < attrs.len() {
         let current_attr = attrs.get(idx).unwrap();
-        if is_arguments_section(current_attr) {
+        if is_parameters_section(current_attr) {
             return Err(syn::Error::new_spanned(
                 current_attr,
                 "Duplicate attribute not allowed.",

--- a/tests/fail/duplicate_arguments_section.rs
+++ b/tests/fail/duplicate_arguments_section.rs
@@ -3,10 +3,10 @@ use roxygen::*;
 #[roxygen]
 /// here are some comments
 /// and some more
-#[arguments_section]
+#[parameters_section]
 /// and some more
 /// but this next argument section should not be here
-#[arguments_section]
+#[parameters_section]
 pub fn add(
     /// some comments
     first: i32,

--- a/tests/fail/duplicate_arguments_section.stderr
+++ b/tests/fail/duplicate_arguments_section.stderr
@@ -1,5 +1,5 @@
 error: Duplicate attribute not allowed.
  --> tests/fail/duplicate_arguments_section.rs:9:1
   |
-9 | #[arguments_section]
-  | ^^^^^^^^^^^^^^^^^^^^
+9 | #[parameters_section]
+  | ^^^^^^^^^^^^^^^^^^^^^

--- a/tests/fail/duplicate_roxygen_attr.rs
+++ b/tests/fail/duplicate_roxygen_attr.rs
@@ -4,10 +4,10 @@ use roxygen::*;
 /// here are some comments
 #[roxygen]
 /// and some more
-#[arguments_section]
+#[parameters_section]
 /// and some more
 /// but this next argument section should not be here
-#[arguments_section]
+#[parameters_section]
 pub fn add(
     /// some comments
     first: i32,

--- a/tests/fail/wrong_arguments_section_placement.stderr
+++ b/tests/fail/wrong_arguments_section_placement.stderr
@@ -4,3 +4,11 @@ error: The #[roxygen] attribute must come before the arguments section attribute
   |
 7 | #[roxygen]
   | ^^^^^^^^^^
+
+warning: use of deprecated macro `arguments_section`: use parameter_section instead
+ --> tests/fail/wrong_arguments_section_placement.rs:5:3
+  |
+5 | #[arguments_section]
+  |   ^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(deprecated)]` on by default

--- a/tests/smoketest.rs
+++ b/tests/smoketest.rs
@@ -4,7 +4,7 @@ use roxygen::*;
 // the real tests are in the macro expansion tests.
 #[roxygen]
 /// hello
-#[arguments_section]
+#[parameters_section]
 ///      this
 ///          is doc
 fn foo(
@@ -19,4 +19,26 @@ fn foo(
 #[test]
 fn test_foo() {
     assert_eq!(foo(1, 3.), -2.);
+}
+
+//@todo(geo) remove this when arguments section is removed
+// just a smoke test that the proc macro can indeed be used like this.
+// the real tests are in the macro expansion tests.
+#[roxygen]
+/// hello
+#[arguments_section]
+///      this
+///          is doc
+fn foo2(
+    /// some comments
+    /// more comments
+    first: i32,
+    second: f32,
+) -> f32 {
+    first as f32 - second
+}
+
+#[test]
+fn test_foo2() {
+    assert_eq!(foo2(1, 3.), -2.);
 }


### PR DESCRIPTION
deprecate the `#[arguments_section]` macro and replace it with `parameters_section`