### PR TITLE
Add an alternative proc macro to allow documenting arguments in a "postfix" position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ proc-macro = true
 quote = "1"
 proc-macro2 = "1.0"
 syn = {version="2.0",features=["parsing","full"]}
+itertools = "0.13.0"
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/Readme.md
+++ b/Readme.md
@@ -31,6 +31,28 @@ fn sum_image_rows(
 } 
 ```
 
+The `#[argdocpos]` attribute allows you to add doc-comments to function
+parameters, but _after_ the parameters.
+You can now write
+
+```rust
+use roxygen::*;
+
+#[argdocpos]
+fn sum_image_rows_pos( /// sum the rows of an image
+  image_data: &    [f32], /// the image data in row-major format
+  nrows     :       u32 , /// the number of rows in the image
+  ncols     :       u32 , /// the number of columns in the image
+  // everything after ///! will become part of the last parameter's comments!
+                          ///! an out buffer into which the resulting
+                          /// sums are placed. Must have space 
+                          /// for exactly `nrows` elements
+  sums      : &mut [f32], // doc comments are illegal here, so use "///!"-split comment syntax from ↑
+) -> Result<(),String> {
+    todo!()
+} 
+```
+
 You have to document at least one parameter (or generic), but you don't have
 to document all of them. The example above will produce documentation as 
 if you had written a doc comment for the function like so:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,8 @@
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, Attribute, ItemFn};
 use util::{
-    extract_documented_generics, extract_documented_parameters, extract_fn_doc_attrs,
-    make_doc_block,
+    extract_documented_generics, extract_documented_parameters,
+    extract_documented_parameters_shift_up, extract_fn_doc_attrs, make_doc_block,
 };
 mod util;
 
@@ -124,9 +124,10 @@ pub fn argdocpos(
     // extrac the doc attributes on the function itself
     let function_docs = try2!(extract_fn_doc_attrs(&mut function.attrs));
 
-    let documented_params = try2!(extract_documented_parameters(
+    let (doc_params_to_fn, documented_params) = try2!(extract_documented_parameters_shift_up(
         function.sig.inputs.iter_mut()
     ));
+    let maybe_empty_doc_par_to_fn: Vec<Attribute> = doc_params_to_fn.unwrap_or_else(|| vec![]);
 
     let documented_generics = try2!(extract_documented_generics(&mut function.sig.generics));
 
@@ -155,6 +156,7 @@ pub fn argdocpos(
 
     quote! {
         #(#docs_before)*
+        #(#maybe_empty_doc_par_to_fn)*
         #parameter_doc_block
         #generics_doc_block
         #maybe_empty_doc_line

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,68 @@ pub fn roxygen(
     .into()
 }
 
+#[proc_macro_attribute]
+/// the principal attribute inside this crate that lets us document function arguments, but after them, not before
+pub fn argdocpos(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let mut function: ItemFn = parse_macro_input!(item as ItemFn);
+
+    try2!(function.attrs.iter_mut().try_for_each(|attr| {
+        if is_argdocpos_main(attr) {
+            Err(syn::Error::new_spanned(
+                attr,
+                "Duplicate attribute. This attribute must only appear once.",
+            ))
+        } else {
+            Ok(())
+        }
+    }));
+
+    // extrac the doc attributes on the function itself
+    let function_docs = try2!(extract_fn_doc_attrs(&mut function.attrs));
+
+    let documented_params = try2!(extract_documented_parameters(
+        function.sig.inputs.iter_mut()
+    ));
+
+    let documented_generics = try2!(extract_documented_generics(&mut function.sig.generics));
+
+    let has_documented_params = !documented_params.is_empty();
+    let has_documented_generics = !documented_generics.is_empty();
+
+    if !has_documented_params && !has_documented_generics {
+        return syn::Error::new_spanned(
+            function.sig.ident,
+            "Function has no documented parameters or generics.\nDocument at least one function parameter or generic.",
+        )
+        .into_compile_error()
+        .into();
+    }
+
+    let parameter_doc_block = make_doc_block("Parameters", documented_params);
+    let generics_doc_block = make_doc_block("Generics", documented_generics);
+
+    let docs_before = function_docs.before_args_section;
+    let docs_after = function_docs.after_args_section;
+    let maybe_empty_doc_line = if !docs_after.is_empty() {
+        Some(quote! {#[doc=""]})
+    } else {
+        None
+    };
+
+    quote! {
+        #(#docs_before)*
+        #parameter_doc_block
+        #generics_doc_block
+        #maybe_empty_doc_line
+        #(#docs_after)*
+        #function
+    }
+    .into()
+}
+
 // this is to expose the helper attribute #[arguments_section].
 // The only logic about this attribute that this here function includes is
 // to make sure that this attribute is not placed before the #[roxygen]
@@ -137,4 +199,10 @@ fn is_parameters_section(attr: &Attribute) -> bool {
 #[inline(always)]
 fn is_roxygen_main(attr: &Attribute) -> bool {
     attr.path().is_ident("roxygen")
+}
+
+/// check whether an attribute is the raw #[argdocpos] main attribute.
+#[inline(always)]
+fn is_argdocpos_main(attr: &Attribute) -> bool {
+    attr.path().is_ident("argdocpos")
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -149,6 +149,88 @@ where
     Ok(documented_params)
 }
 
+use syn::ExprLit;
+use syn::Lit;
+use itertools::{Itertools, Position as IPos};
+
+/// Same as extract_documented_parameters, but shifts all docs by -1, returning the 1st parameter's docs separately,
+/// so that it can be used as a function comment
+/// Also allows splitting the last parameter's docs into 2: belonging to the last parameter (after ///!) and to the previous one
+///
+/// fn sum_image_rows( /// this comment belongs to the function, not to the next parameter, so will be returned separately
+///  image_data : &[f32],/// this comment belongs to the preceding `image_data` parameter, not `nrows`
+///  nrows      :   u32 ,/// this part of the comment belongs to `nrows`
+///                             ///! but this part — to the last `ncols` parameter
+///  ncols      :   u32 ,// it's a syntax error to add doc comments at the end
+/// )
+pub fn extract_documented_parameters_shift_up<'a, I>(args: I) -> Result<(Option<Vec<Attribute>>,Vec<DocumentedIdent<'a>>), syn::Error>
+where
+    I: Iterator<Item = &'a mut FnArg>,
+{
+    // will contain the docs comments for each documented function parameter
+    // together with the identifier of the function parameter.
+    let (lower, upper) = args.size_hint();
+    let mut documented_params = Vec::<DocumentedIdent>::with_capacity(upper.unwrap_or(lower));
+
+    let mut docs0     :Option<Vec::<Attribute>> = None;
+    let mut ident_prev:Option<&Ident> = None;
+    let mut ident_last:Option<&Ident> = None;
+    let mut docs_last :Vec::<Attribute> = vec![];
+    for (pos,arg) in args.with_position() {
+        match arg {
+            FnArg::Typed(pat_type) => {
+                let Pat::Ident(pat_ident) = pat_type.pat.as_ref() else {unreachable!("unexpected node while parsing");};
+                let ident = &pat_ident.ident;
+                let docs = extract_doc_attrs(&mut pat_type.attrs);
+
+                if !docs.is_empty() {
+                    match pos {
+                        IPos::Only   => {ident_last = Some(ident); docs_last =      docs;},
+                        IPos::First  => {ident_prev = Some(ident); docs0     = Some(docs);},
+                        IPos::Middle => {documented_params.push(DocumentedIdent::new(ident_prev.take().expect("preserved prev ident"), docs));
+                                         ident_prev = Some(ident);},
+                        IPos::Last   => {documented_params.push(DocumentedIdent::new(ident_prev.take().expect("preserved prev ident"), docs.clone()));
+                                         ident_last = Some(ident); docs_last =      docs},
+                    }
+                }
+            }
+            FnArg::Receiver(_) => {}
+        }
+    }
+    let mut is_split = false;
+    if let Some(ident_last) = ident_last { // on ///! split the docs between 2 parameters, removing !
+        let mut docs_last_2prev:Vec::<Attribute> = vec![];
+        let mut docs_last_2last:Vec::<Attribute> = vec![];
+        for mut attr in docs_last {
+            if let Meta::NameValue(MetaNameValue {value: Expr::Lit(ExprLit{lit: Lit::Str(ref mut lit_s),..}),..}) = attr.meta {
+                if ! is_split {
+                    let s = lit_s.value();
+                    if s.starts_with('!') {
+                        is_split = true;
+                        *lit_s = LitStr::new(&s[1..s.len()], lit_s.span());
+                        docs_last_2last.push(attr); // assign post ///! doc lines to the last parameter
+                    } else {
+                        docs_last_2prev.push(attr);
+                    }
+                } else { // everything post stplit goes to the last parameter, ignore further ///!
+                        docs_last_2last.push(attr);
+                }
+            }
+        }
+        if ! docs_last_2last.is_empty() {
+            if let Some(mut docum_par_prev) = documented_params.pop() {
+              docum_par_prev.docs = docs_last_2prev;
+              documented_params.push(docum_par_prev);
+              documented_params.push(DocumentedIdent::new(ident_last, docs_last_2last));
+            } else {
+                docs0 = Some(docs_last_2prev);
+                documented_params.push(DocumentedIdent::new(ident_last, docs_last_2last));
+            }
+        }
+    }
+    Ok((docs0,documented_params))
+}
+
 /// same as extracting documentatio from parameters, but for generic types
 pub fn extract_documented_generics(
     generics: &'_ mut Generics,

--- a/tests/expansion/argdocpos_only.rs
+++ b/tests/expansion/argdocpos_only.rs
@@ -1,0 +1,14 @@
+use roxygen::*;
+
+#[argdocpos]
+fn foo(
+    /// this is documentation
+    /// and this is too
+    // but this is not
+    bar: u32, /// this has one line of docs
+    baz: String, /// this has
+    /// two lines of docs
+    _undocumented: i32,
+) -> bool {
+    baz.len() > bar as usize
+}

--- a/tests/expansion/argdocpos_with_args_section_and_generics.rs
+++ b/tests/expansion/argdocpos_with_args_section_and_generics.rs
@@ -1,0 +1,23 @@
+use roxygen::*;
+
+#[roxygen]
+/// this is documentation
+/// and this is too
+#[parameters_section]
+fn foo<
+    /// a lifetime
+    'a,
+    S,
+    /// documentation for parameter T
+    /// spans multiple lines
+    T,
+    /// a const generic
+    const N: usize,
+>( /// this goes after the arguments section
+    bar: u32, /// this has one line of docs
+    baz: String, /// this has
+    /// two lines of docs
+    _undocumented: i32,
+) -> bool {
+    baz.len() > bar as usize
+}

--- a/tests/expansion/argdocpos_with_argument_section.rs
+++ b/tests/expansion/argdocpos_with_argument_section.rs
@@ -1,0 +1,14 @@
+use roxygen::*;
+
+#[roxygen]
+/// this is documentation
+/// and this is too
+#[parameters_section]
+fn foo( /// this goes after the arguments section
+    bar: u32, /// this has one line of docs
+    baz: String, /// this has
+    /// two lines of docs
+    _undocumented: i32,
+) -> bool {
+    baz.len() > bar as usize
+}


### PR DESCRIPTION
Allows this nicely aligned doc format with `///!` separating the last valid comment between the last 2 arguments

```rs
#[argdocpos]
fn sum_image_rows_pos( /// sum the rows of an image
  image_data: &    [f32], /// the image data in row-major format
  nrows     :       u32 , /// the number of rows in the image
  ncols     :       u32 , /// the number of columns in the image
                          ///! an out buffer into which the resulting
                          /// sums are placed. Must have space 
                          /// for exactly `nrows` elements
  sums      : &mut [f32],
) -> Result<(),String> {
    todo!()
} 
```
Closes https://github.com/geo-ant/roxygen/issues/13

Not sure how to block both, but from a couple of checks they seem to fail as is when used together

I've copied some tests, but then the current tests fail for me due to a missing `expand` command, so can't test the new ones either