### PR TITLE
more flexible and minimalist function parsing

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,8 +45,8 @@ if you had written a doc comment for the function like so:
 /// * `nrows`: the number of rows in the image
 /// * `ncols`: the number of columns in the image
 /// * `sums`: an out buffer into which the resulting
-///    sums are placed. Must have space 
-///    for exactly `nrows` elements
+///   sums are placed. Must have space 
+///   for exactly `nrows` elements
 fn sum_image_rows(
   image_data: &[f32],
   nrows: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@ use util::{
     extract_documented_generics, extract_documented_parameters, extract_fn_doc_attrs,
     make_doc_block,
 };
+
+use crate::minfun::MinimalistItemFn;
+/// more general parsing that only parses function signature and after that
+/// just streams as is.
+mod minfun;
 mod util;
 
 /// parameter section macro name
@@ -54,7 +59,7 @@ pub fn roxygen(
     _attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    let mut function: ItemFn = parse_macro_input!(item as ItemFn);
+    let mut function = parse_macro_input!(item as MinimalistItemFn);
 
     try2!(function.attrs.iter_mut().try_for_each(|attr| {
         if is_roxygen_main(attr) {

--- a/src/minfun.rs
+++ b/src/minfun.rs
@@ -1,0 +1,58 @@
+/// Forgive me lord for I have sinned... I've copy pasted my own code from
+/// the doxidize crate, see https://github.com/geo-ant/doxidize/tree/main/src
+///
+// TODO(geo-ant): either factor this out into it's own crate OR better yet,
+// factor this out into it's own crate AND get rid of the syn dependency...
+use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt};
+use syn::{parse::Parse, AttrStyle, Attribute, Signature, Visibility};
+
+/// This mirrors the ItemFn item in the syn crate with the difference
+/// that the `block` isn't parsed, it's just a tokenstream, which should
+/// be faster than parsing the actual block as well. We don't need the block
+/// to be parsed for the logic inside this crate.
+pub struct MinimalistItemFn {
+    pub attrs: Vec<Attribute>,
+    pub vis: Visibility,
+    pub sig: Signature,
+    pub block: TokenStream,
+}
+
+impl ToTokens for MinimalistItemFn {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        // NOTE(geo-ant): this is the same as the `ToTokens` implementation
+        // for ItemFn in the syn crate. The only difference in implementation
+        // is that the attributes are appended using
+        //
+        // ```
+        // tokens.append_all(self.attrs.outer());
+        // ```
+        //
+        // which I can't use here because it uses an internal crate iterator
+        // helper, which does the same filtering as I do here.
+        // Also, obviously the block tokenization is more involved in syn,
+        // whereas we can just spit out the block as-is.
+
+        tokens.append_all(
+            self.attrs
+                .iter()
+                .filter(|attr| matches!(attr.style, AttrStyle::Outer)),
+        );
+        self.vis.to_tokens(tokens);
+        self.sig.to_tokens(tokens);
+        self.block.to_tokens(tokens);
+    }
+}
+
+impl Parse for MinimalistItemFn {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // same logic as in the syn crate with the difference that the
+        // block is just read as is.
+        Ok(Self {
+            attrs: input.call(Attribute::parse_outer)?,
+            vis: input.parse()?,
+            sig: input.parse()?,
+            block: input.parse()?,
+        })
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -201,7 +201,7 @@ where
         let first_line = prepend_to_doc_attribute(&format!(" * `{}`:", param.ident), first);
 
         // we just need to indent the other lines, if they exist
-        let next_lines = docs_iter.map(|attr| prepend_to_doc_attribute("   ", attr));
+        let next_lines = docs_iter.map(|attr| prepend_to_doc_attribute("  ", attr));
         quote! {
             #first_line
             #(#next_lines)*

--- a/tests/expansion/roxygen_only.expanded.rs
+++ b/tests/expansion/roxygen_only.expanded.rs
@@ -6,7 +6,7 @@ use roxygen::*;
 ///
 /// * `bar`: this has one line of docs
 /// * `baz`: this has
-///    two lines of docs
+///   two lines of docs
 fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
     baz.len() > bar as usize
 }

--- a/tests/expansion/roxygen_with_args_section_and_generics.expanded.rs
+++ b/tests/expansion/roxygen_with_args_section_and_generics.expanded.rs
@@ -6,13 +6,13 @@ use roxygen::*;
 ///
 /// * `bar`: this has one line of docs
 /// * `baz`: this has
-///    two lines of docs
+///   two lines of docs
 ///
 /// **Generics**:
 ///
 /// * `a`: a lifetime
 /// * `T`: documentation for parameter T
-///    spans multiple lines
+///   spans multiple lines
 /// * `N`: a const generic
 ///
 /// this goes after the arguments section

--- a/tests/expansion/roxygen_with_argument_section.expanded.rs
+++ b/tests/expansion/roxygen_with_argument_section.expanded.rs
@@ -6,7 +6,7 @@ use roxygen::*;
 ///
 /// * `bar`: this has one line of docs
 /// * `baz`: this has
-///    two lines of docs
+///   two lines of docs
 ///
 /// this goes after the arguments section
 fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {

--- a/tests/expansion/roxygen_works_in_impl_blocks.expanded.rs
+++ b/tests/expansion/roxygen_works_in_impl_blocks.expanded.rs
@@ -1,0 +1,17 @@
+use roxygen::*;
+struct Foo {
+    something: i32,
+}
+impl Foo {
+    /// this is documentation
+    /// and this is too
+    ///
+    /// **Parameters**:
+    ///
+    /// * `bar`: this has one line of docs
+    /// * `baz`: this has
+    ///    two lines of docs
+    fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
+        baz.len() > bar as usize
+    }
+}

--- a/tests/expansion/roxygen_works_in_impl_blocks.expanded.rs
+++ b/tests/expansion/roxygen_works_in_impl_blocks.expanded.rs
@@ -10,7 +10,7 @@ impl Foo {
     ///
     /// * `bar`: this has one line of docs
     /// * `baz`: this has
-    ///    two lines of docs
+    ///   two lines of docs
     fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
         baz.len() > bar as usize
     }

--- a/tests/expansion/roxygen_works_in_impl_blocks.rs
+++ b/tests/expansion/roxygen_works_in_impl_blocks.rs
@@ -1,0 +1,18 @@
+use roxygen::*;
+struct Foo {
+    something: i32,
+}
+
+impl Foo {
+    /// this is documentation
+    /// and this is too
+    ///
+    /// **Parameters**:
+    ///
+    /// * `bar`: this has one line of docs
+    /// * `baz`: this has
+    ///    two lines of docs
+    fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
+        baz.len() > bar as usize
+    }
+}

--- a/tests/expansion/roxygen_works_in_impl_blocks.rs
+++ b/tests/expansion/roxygen_works_in_impl_blocks.rs
@@ -4,15 +4,18 @@ struct Foo {
 }
 
 impl Foo {
+    #[roxygen]
     /// this is documentation
     /// and this is too
-    ///
-    /// **Parameters**:
-    ///
-    /// * `bar`: this has one line of docs
-    /// * `baz`: this has
-    ///    two lines of docs
-    fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
+    // but this is not
+    fn foo(
+        /// this has one line of docs
+        bar: u32,
+        /// this has
+        /// two lines of docs
+        baz: String,
+        _undocumented: i32,
+    ) -> bool {
         baz.len() > bar as usize
     }
 }

--- a/tests/expansion/roxygen_works_in_traits.expanded.rs
+++ b/tests/expansion/roxygen_works_in_traits.expanded.rs
@@ -11,4 +11,21 @@ trait Foo {
     fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
         baz.len() > bar as usize
     }
+    /// I almost forgot the whole point was to test
+    /// whether it works for functions without body...
+    /// it should...
+    ///
+    /// **Parameters**:
+    ///
+    /// * `first`: the first parameter
+    /// * `second`: the second, more interesting parameter
+    ///    with more interesting
+    ///
+    ///    ```rust
+    ///      docs = very_interesting!();
+    ///    ```
+    ///
+    ///    Sorry it's kinda late and I'm tired... but my professional
+    ///    honor is not letting me skip this test.
+    fn bar(first: i32, second: f32);
 }

--- a/tests/expansion/roxygen_works_in_traits.expanded.rs
+++ b/tests/expansion/roxygen_works_in_traits.expanded.rs
@@ -1,0 +1,14 @@
+use roxygen::*;
+trait Foo {
+    /// this is documentation
+    /// and this is too
+    ///
+    /// **Parameters**:
+    ///
+    /// * `bar`: this has one line of docs
+    /// * `baz`: this has
+    ///    two lines of docs
+    fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
+        baz.len() > bar as usize
+    }
+}

--- a/tests/expansion/roxygen_works_in_traits.expanded.rs
+++ b/tests/expansion/roxygen_works_in_traits.expanded.rs
@@ -18,14 +18,13 @@ trait Foo {
     /// **Parameters**:
     ///
     /// * `first`: the first parameter
-    /// * `second`: the second, more interesting parameter
-    ///    with more interesting
+    /// * `second`:    with more interesting
     ///
-    ///    ```rust
-    ///      docs = very_interesting!();
-    ///    ```
+    ///       ```rust
+    ///         docs = very_interesting!();
+    ///       ```
     ///
-    ///    Sorry it's kinda late and I'm tired... but my professional
-    ///    honor is not letting me skip this test.
+    ///       Sorry it's kinda late and I'm tired... but my professional
+    ///       honor is not letting me skip this test.
     fn bar(first: i32, second: f32);
 }

--- a/tests/expansion/roxygen_works_in_traits.expanded.rs
+++ b/tests/expansion/roxygen_works_in_traits.expanded.rs
@@ -7,7 +7,7 @@ trait Foo {
     ///
     /// * `bar`: this has one line of docs
     /// * `baz`: this has
-    ///    two lines of docs
+    ///   two lines of docs
     fn foo(bar: u32, baz: String, _undocumented: i32) -> bool {
         baz.len() > bar as usize
     }
@@ -20,11 +20,11 @@ trait Foo {
     /// * `first`: the first parameter
     /// * `second`: the second parameter, with more interesting
     ///
-    ///    ```rust
-    ///      docs = very_interesting!();
-    ///    ```
+    ///   ```rust
+    ///     docs = very_interesting!();
+    ///   ```
     ///
-    ///    Sorry it's kinda late and I'm tired... but my professional
-    ///    honor is not letting me skip this test.
+    ///   Sorry it's kinda late and I'm tired... but my professional
+    ///   honor is not letting me skip this test.
     fn bar(first: i32, second: f32);
 }

--- a/tests/expansion/roxygen_works_in_traits.expanded.rs
+++ b/tests/expansion/roxygen_works_in_traits.expanded.rs
@@ -18,13 +18,13 @@ trait Foo {
     /// **Parameters**:
     ///
     /// * `first`: the first parameter
-    /// * `second`:    with more interesting
+    /// * `second`: the second parameter, with more interesting
     ///
-    ///       ```rust
-    ///         docs = very_interesting!();
-    ///       ```
+    ///    ```rust
+    ///      docs = very_interesting!();
+    ///    ```
     ///
-    ///       Sorry it's kinda late and I'm tired... but my professional
-    ///       honor is not letting me skip this test.
+    ///    Sorry it's kinda late and I'm tired... but my professional
+    ///    honor is not letting me skip this test.
     fn bar(first: i32, second: f32);
 }

--- a/tests/expansion/roxygen_works_in_traits.rs
+++ b/tests/expansion/roxygen_works_in_traits.rs
@@ -16,21 +16,21 @@ trait Foo {
         baz.len() > bar as usize
     }
 
+    #[roxygen]
     /// I almost forgot the whole point was to test
     /// whether it works for functions without body...
     /// it should...
-    ///
-    /// **Parameters**:
-    ///
-    /// * `first`: the first parameter
-    /// * `second`: the second, more interesting parameter
-    ///    with more interesting
-    ///
-    ///    ```rust
-    ///      docs = very_interesting!();
-    ///    ```
-    ///
-    ///    Sorry it's kinda late and I'm tired... but my professional
-    ///    honor is not letting me skip this test.
-    fn bar(first: i32, second: f32);
+    fn bar(
+        /// the first parameter
+        first: i32,
+        ///    with more interesting
+        ///
+        ///    ```rust
+        ///      docs = very_interesting!();
+        ///    ```
+        ///
+        ///    Sorry it's kinda late and I'm tired... but my professional
+        ///    honor is not letting me skip this test.
+        second: f32,
+    );
 }

--- a/tests/expansion/roxygen_works_in_traits.rs
+++ b/tests/expansion/roxygen_works_in_traits.rs
@@ -23,14 +23,14 @@ trait Foo {
     fn bar(
         /// the first parameter
         first: i32,
-        ///    with more interesting
+        /// the second parameter, with more interesting
         ///
-        ///    ```rust
-        ///      docs = very_interesting!();
-        ///    ```
+        /// ```rust
+        ///   docs = very_interesting!();
+        /// ```
         ///
-        ///    Sorry it's kinda late and I'm tired... but my professional
-        ///    honor is not letting me skip this test.
+        /// Sorry it's kinda late and I'm tired... but my professional
+        /// honor is not letting me skip this test.
         second: f32,
     );
 }

--- a/tests/expansion/roxygen_works_in_traits.rs
+++ b/tests/expansion/roxygen_works_in_traits.rs
@@ -15,4 +15,22 @@ trait Foo {
     ) -> bool {
         baz.len() > bar as usize
     }
+
+    /// I almost forgot the whole point was to test
+    /// whether it works for functions without body...
+    /// it should...
+    ///
+    /// **Parameters**:
+    ///
+    /// * `first`: the first parameter
+    /// * `second`: the second, more interesting parameter
+    ///    with more interesting
+    ///
+    ///    ```rust
+    ///      docs = very_interesting!();
+    ///    ```
+    ///
+    ///    Sorry it's kinda late and I'm tired... but my professional
+    ///    honor is not letting me skip this test.
+    fn bar(first: i32, second: f32);
 }

--- a/tests/expansion/roxygen_works_in_traits.rs
+++ b/tests/expansion/roxygen_works_in_traits.rs
@@ -1,0 +1,18 @@
+use roxygen::*;
+
+trait Foo {
+    #[roxygen]
+    /// this is documentation
+    /// and this is too
+    // but this is not
+    fn foo(
+        /// this has one line of docs
+        bar: u32,
+        /// this has
+        /// two lines of docs
+        baz: String,
+        _undocumented: i32,
+    ) -> bool {
+        baz.len() > bar as usize
+    }
+}


### PR DESCRIPTION
Stole some code from my own `doxidize` crate to fix issue #21 and make the parsing more minimalist in the process.